### PR TITLE
Dev

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -75,7 +75,8 @@
       "Bash(del \"D:\\delwer\\ai-bud-all\\idean-all\\idean-ai-delwer\\src\\app\\(dashboard)\\dashboard\\copywriting\\[id]\\response_1757864048377.json\")",
       "Bash(del \"E:\\test\\other\\ai\\idea-ai\\src\\app\\(dashboard)\\dashboard\\blueprints\\page.tsx\")",
       "Bash(rm:*)",
-      "Bash(pnmp:*)"
+      "Bash(pnmp:*)",
+      "WebFetch(domain:www.ideanconsulting.com)"
     ],
     "deny": [],
     "ask": [],

--- a/src/app/(dashboard)/dashboard/copywriting/page.tsx
+++ b/src/app/(dashboard)/dashboard/copywriting/page.tsx
@@ -92,7 +92,7 @@ export default function CopywritingPage() {
       description: 'Psychology-driven copywriting that triggers buying behavior',
       category: 'Psychology',
       icon: Zap,
-      color: 'bg-yellow-500',
+      color: 'bg-blue-500',
       estimatedTime: '15-20 minutes'
     },
     {
@@ -101,7 +101,7 @@ export default function CopywritingPage() {
       description: 'Viral content creation framework for maximum engagement',
       category: 'Content',
       icon: TrendingUp,
-      color: 'bg-red-500',
+      color: 'bg-blue-600',
       estimatedTime: '20-25 minutes'
     },
     {
@@ -110,7 +110,7 @@ export default function CopywritingPage() {
       description: 'Automated email campaigns that convert and nurture',
       category: 'Email',
       icon: Mail,
-      color: 'bg-blue-500',
+      color: 'bg-blue-400',
       estimatedTime: '25-30 minutes'
     },
     {
@@ -119,7 +119,7 @@ export default function CopywritingPage() {
       description: 'Platform-optimized social media content generation',
       category: 'Social',
       icon: Share2,
-      color: 'bg-green-500',
+      color: 'bg-emerald-500',
       estimatedTime: '10-15 minutes'
     },
     {
@@ -128,7 +128,7 @@ export default function CopywritingPage() {
       description: 'High-converting sales pages with proven structures',
       category: 'Sales',
       icon: Target,
-      color: 'bg-purple-500',
+      color: 'bg-slate-600',
       estimatedTime: '30-40 minutes'
     },
     {
@@ -137,7 +137,7 @@ export default function CopywritingPage() {
       description: 'Facebook, Google, and native ad copy that converts',
       category: 'Advertising',
       icon: Sparkles,
-      color: 'bg-indigo-500',
+      color: 'bg-teal-600',
       estimatedTime: '12-18 minutes'
     }
   ]
@@ -173,7 +173,7 @@ export default function CopywritingPage() {
       {/* Header */}
       <div className="mb-8">
         <div className="flex items-center gap-3 mb-2">
-          <div className="w-10 h-10 bg-orange-600 rounded-lg flex items-center justify-center">
+          <div className="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
             <PenTool className="w-5 h-5 text-white" />
           </div>
           <div>
@@ -211,7 +211,7 @@ export default function CopywritingPage() {
           <Filter className="w-4 h-4 mr-2" />
           Search
         </Button>
-        <Button className="bg-orange-600 hover:bg-orange-700">
+        <Button className="bg-blue-600 hover:bg-blue-700">
           <Plus className="w-4 h-4 mr-2" />
           Create Framework
         </Button>
@@ -394,7 +394,7 @@ export default function CopywritingPage() {
       {/* Quick Start Guide */}
       <Card className="p-6 bg-gradient-to-r from-orange-50 to-yellow-50 border-orange-200">
         <div className="flex items-center gap-4">
-          <div className="w-12 h-12 bg-orange-600 rounded-lg flex items-center justify-center">
+          <div className="w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center">
             <PenTool className="w-6 h-6 text-white" />
           </div>
           <div className="flex-1">
@@ -409,7 +409,7 @@ export default function CopywritingPage() {
             </div>
           </div>
           <Button
-            className="bg-orange-600 hover:bg-orange-700"
+            className="bg-blue-600 hover:bg-blue-700"
             onClick={() => {
               if (copywritings.length > 0) {
                 handleCopywritingClick(copywritings[0])

--- a/src/app/(dashboard)/dashboard/page.tsx
+++ b/src/app/(dashboard)/dashboard/page.tsx
@@ -327,7 +327,7 @@ export default function DashboardPage() {
             <div className="w-14 h-14 bg-gradient-to-br from-purple-500 to-purple-600 rounded-xl flex items-center justify-center group-hover:scale-110 transition-transform">
               <Palette className="w-7 h-7 text-white" />
             </div>
-            <span className="text-xs bg-purple-100 text-purple-700 px-3 py-1 rounded-full font-medium">Brand DNA</span>
+            <span className="text-xs bg-teal-100 text-teal-700 px-3 py-1 rounded-full font-medium">Brand DNA</span>
           </div>
           <h3 className="text-xl font-bold text-gray-900 mb-2 group-hover:text-purple-600 transition-colors">Branding Lab</h3>
           <p className="text-gray-600 text-sm mb-4 leading-relaxed">
@@ -346,7 +346,7 @@ export default function DashboardPage() {
             </div>
           </div>
           
-          <Button className="w-full group-hover:bg-purple-600 group-hover:text-white" variant="outline">
+          <Button className="w-full group-hover:bg-blue-600 group-hover:text-white" variant="outline">
             Build Your Brand
             <Crown className="w-4 h-4 ml-2" />
           </Button>
@@ -378,7 +378,7 @@ export default function DashboardPage() {
             </div>
           </div>
           
-          <Button className="w-full group-hover:bg-orange-600 group-hover:text-white" variant="outline">
+          <Button className="w-full group-hover:bg-blue-600 group-hover:text-white" variant="outline">
             Generate Content
             <Sparkles className="w-4 h-4 ml-2" />
           </Button>
@@ -456,7 +456,7 @@ export default function DashboardPage() {
         {/* Business Health Dashboard */}
         <Card className="p-6">
           <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
+            <div className="w-10 h-10 bg-emerald-100 rounded-lg flex items-center justify-center">
               <Activity className="w-5 h-5 text-green-600" />
             </div>
             <h3 className="text-lg font-bold text-gray-900">Business Health Score</h3>
@@ -568,7 +568,7 @@ export default function DashboardPage() {
 
         <Card className="p-6">
           <div className="flex items-center justify-between mb-4">
-            <div className="w-12 h-12 bg-green-100 rounded-lg flex items-center justify-center">
+            <div className="w-12 h-12 bg-emerald-100 rounded-lg flex items-center justify-center">
               <FileText className="w-6 h-6 text-green-600" />
             </div>
             <span className="text-2xl font-bold text-gray-900">{dashboardData.analytics.frameworks.completed}</span>
@@ -579,7 +579,7 @@ export default function DashboardPage() {
 
         <Card className="p-6">
           <div className="flex items-center justify-between mb-4">
-            <div className="w-12 h-12 bg-purple-100 rounded-lg flex items-center justify-center">
+            <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
               <Building className="w-6 h-6 text-purple-600" />
             </div>
             <span className="text-2xl font-bold text-gray-900">{dashboardData.analytics.totalDocuments}</span>
@@ -590,7 +590,7 @@ export default function DashboardPage() {
 
         <Card className="p-6">
           <div className="flex items-center justify-between mb-4">
-            <div className="w-12 h-12 bg-orange-100 rounded-lg flex items-center justify-center">
+            <div className="w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center">
               <Globe className="w-6 h-6 text-orange-600" />
             </div>
             <span className="text-2xl font-bold text-gray-900">{industry}</span>

--- a/src/app/(main)/login/page.tsx
+++ b/src/app/(main)/login/page.tsx
@@ -11,14 +11,14 @@ export default function LoginPage() {
       {/* Header with navigation */}
       <div className="flex justify-between items-center p-6 border-b border-gray-100">
         <Link href="/" className="flex items-center space-x-2">
-          <div className="w-8 h-8 bg-black rounded-lg flex items-center justify-center">
+          <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
             <span className="text-sm font-bold text-white">iA</span>
           </div>
           <span className="text-xl font-semibold text-gray-900">iDEAN AI</span>
         </Link>
         <div className="flex space-x-4">
           <Link href="/onboarding">
-            <Button className="bg-black hover:bg-gray-800 text-white font-medium">
+            <Button className="bg-blue-600 hover:bg-blue-700 text-white font-medium">
               Get Started
             </Button>
           </Link>

--- a/src/app/(main)/onboarding/page.tsx
+++ b/src/app/(main)/onboarding/page.tsx
@@ -213,7 +213,7 @@ export default function OnboardingPage() {
               <div
                 className={`w-3 h-3 rounded-full transition-all duration-300 ${
                   index < currentStep
-                    ? 'bg-green-500 ring-2 ring-green-100'
+                    ? 'bg-blue-500 ring-2 ring-blue-100'
                     : index === currentStep
                     ? 'bg-black ring-2 ring-gray-100 scale-125'
                     : 'bg-gray-200'
@@ -222,7 +222,7 @@ export default function OnboardingPage() {
               {index < currentSteps.length - 1 && (
                 <div
                   className={`w-8 h-px mx-1 transition-colors duration-300 ${
-                    index < currentStep ? 'bg-green-300' : 'bg-gray-200'
+                    index < currentStep ? 'bg-blue-300' : 'bg-gray-200'
                   }`}
                 />
               )}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -13,14 +13,14 @@ export default function Home() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-4">
             <Link href="/" className="flex items-center space-x-2">
-              <div className="w-8 h-8 bg-black rounded-lg flex items-center justify-center">
+              <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
                 <span className="text-white font-bold text-sm">iA</span>
               </div>
               <span className="font-bold text-xl text-gray-900">iDEAN AI</span>
             </Link>
             <div className="flex items-center space-x-6">
               <Link href="/dashboard/onboarding">
-                <Button className="bg-black hover:bg-gray-800 text-white font-medium">
+                <Button className="bg-blue-600 hover:bg-blue-700 text-white font-medium">
                   Get Started
                 </Button>
               </Link>
@@ -48,7 +48,7 @@ export default function Home() {
               <Link href="/dashboard/onboarding">
                 <Button
                   size="lg"
-                  className="bg-black hover:bg-gray-800 text-white px-8 py-3 text-base font-medium"
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-3 text-base font-medium"
                 >
                   Get Started
                   <ArrowRight className="ml-2 w-4 h-4" />
@@ -85,24 +85,24 @@ export default function Home() {
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-20">
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
           <div className="text-center">
-            <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center mx-auto mb-4">
-              <Target className="w-6 h-6 text-gray-700" />
+            <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mx-auto mb-4">
+              <Target className="w-6 h-6 text-blue-600" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">Strategy</h3>
             <p className="text-gray-600">Proven business frameworks</p>
           </div>
 
           <div className="text-center">
-            <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center mx-auto mb-4">
-              <Rocket className="w-6 h-6 text-gray-700" />
+            <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mx-auto mb-4">
+              <Rocket className="w-6 h-6 text-blue-600" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">Execution</h3>
             <p className="text-gray-600">Marketing tools and campaigns</p>
           </div>
 
           <div className="text-center">
-            <div className="w-12 h-12 bg-gray-100 rounded-xl flex items-center justify-center mx-auto mb-4">
-              <Sparkles className="w-6 h-6 text-gray-700" />
+            <div className="w-12 h-12 bg-teal-100 rounded-xl flex items-center justify-center mx-auto mb-4">
+              <Sparkles className="w-6 h-6 text-teal-600" />
             </div>
             <h3 className="text-lg font-semibold text-gray-900 mb-2">Content</h3>
             <p className="text-gray-600">AI-powered content creation</p>
@@ -111,7 +111,7 @@ export default function Home() {
       </div>
 
       {/* CTA Section */}
-      <div className="bg-gray-900">
+      <div className="bg-slate-800">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-20 text-center">
           <h2 className="text-3xl font-semibold text-white mb-6">
             Ready to get started?
@@ -119,7 +119,7 @@ export default function Home() {
           <Link href="/dashboard/onboarding">
             <Button
               size="lg"
-              className="bg-white text-gray-900 hover:bg-gray-100 px-8 py-3 text-base font-medium"
+              className="bg-white text-blue-600 hover:bg-blue-50 px-8 py-3 text-base font-medium"
             >
               Start Now
               <ArrowRight className="ml-2 w-4 h-4" />

--- a/src/app/(main)/signup/page.tsx
+++ b/src/app/(main)/signup/page.tsx
@@ -97,7 +97,7 @@ export default function SignupPage() {
       {/* Header with login link */}
       <div className="absolute top-0 left-0 right-0 flex justify-between items-center p-6">
         <Link href="/" className="flex items-center space-x-2">
-          <div className="w-8 h-8 bg-black rounded-lg flex items-center justify-center">
+          <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
             <span className="text-sm font-bold text-white">iA</span>
           </div>
           <span className="text-xl font-semibold text-gray-900">iDEAN AI</span>
@@ -207,7 +207,7 @@ export default function SignupPage() {
 
                 <Button
                   type="submit"
-                  className="w-full h-11 bg-black hover:bg-gray-800 text-white font-medium rounded-md"
+                  className="w-full h-11 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md"
                   disabled={loading}
                 >
                   {loading ? 'Signing up...' : 'Sign up'}

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -151,7 +151,7 @@ export function LoginForm() {
 
             <Button
               type="submit"
-              className="w-full h-11 bg-black hover:bg-gray-800 text-white font-medium rounded-md"
+              className="w-full h-11 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-md"
               disabled={loading}
             >
               {loading ? 'Signing in...' : 'Continue'}

--- a/src/components/copywriting/GenerationModal.tsx
+++ b/src/components/copywriting/GenerationModal.tsx
@@ -797,7 +797,7 @@ ${inputs.ctaText || 'Take action now!'}
               </Button>
             )}
             {currentStep === 4 && (
-              <Button onClick={onClose} className="bg-green-600 hover:bg-green-700">
+              <Button onClick={onClose} className="bg-blue-600 hover:bg-blue-700">
                 <CheckCircle className="w-4 h-4 mr-2" />
                 Complete
               </Button>


### PR DESCRIPTION
This pull request updates the application's color palette to use blue and teal tones more consistently across the UI, replacing previous uses of orange, green, purple, and black. The changes affect button styles, card backgrounds, icons, and progress indicators, resulting in a more unified and modern look throughout the dashboard, copywriting, onboarding, authentication, and home pages.

**UI Color Palette Updates**

* Updated button and icon background colors in the copywriting dashboard to use blue and teal shades instead of orange, green, red, purple, and indigo, ensuring visual consistency across frameworks and actions (`src/app/(dashboard)/dashboard/copywriting/page.tsx`). [[1]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L95-R95) [[2]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L104-R104) [[3]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L113-R113) [[4]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L122-R122) [[5]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L131-R131) [[6]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L140-R140) [[7]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L176-R176) [[8]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L214-R214) [[9]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L397-R397) [[10]](diffhunk://#diff-ca297f5e6367371798a870409ae5627edb67db9e090f0880bb15c69993877fa5L412-R412)
* Changed branding and content-related accent colors in the main dashboard, including badges, buttons, and card backgrounds, to use blue and teal tones instead of purple, orange, and green (`src/app/(dashboard)/dashboard/page.tsx`). [[1]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L330-R330) [[2]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L349-R349) [[3]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L381-R381) [[4]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L459-R459) [[5]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L571-R571) [[6]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L582-R582) [[7]](diffhunk://#diff-c393978e2702f273c6f9187e9d9172abe2ebf1f1260834ad48fe3d5c08f7b721L593-R593)

**Authentication and Onboarding**

* Updated button and icon backgrounds in login and signup pages to use blue instead of black, and adjusted onboarding progress indicators to use blue instead of green (`src/app/(main)/login/page.tsx`, `src/app/(main)/signup/page.tsx`, `src/app/(main)/onboarding/page.tsx`, `src/components/auth/LoginForm.tsx`). [[1]](diffhunk://#diff-2f0a30e78cb03d30bc10827ddd0681533433649de943b05b48524de9a8384c31L14-R21) [[2]](diffhunk://#diff-69bea409341211d47de9ab7e6d407f231333ed9e08b08fde9e1c5df2d12f76b5L100-R100) [[3]](diffhunk://#diff-69bea409341211d47de9ab7e6d407f231333ed9e08b08fde9e1c5df2d12f76b5L210-R210) [[4]](diffhunk://#diff-d83c9012dd29a9aebb1a731df7749110bdb34e628167dd661a81047477df5f89L216-R216) [[5]](diffhunk://#diff-d83c9012dd29a9aebb1a731df7749110bdb34e628167dd661a81047477df5f89L225-R225) [[6]](diffhunk://#diff-855a46874d9a3936b861b4c7ec43af9bf3fce31195978efd703533611eaaac59L154-R154)

**Home Page Visuals**

* Refreshed home page icons and call-to-action sections with blue and teal backgrounds and accents, replacing gray and black for a more vibrant appearance (`src/app/(main)/page.tsx`). [[1]](diffhunk://#diff-90f2fd3077ab6e179d8d0c5770730744823d1c3054847cfeed8c6bbb0eef3e5dL16-R23) [[2]](diffhunk://#diff-90f2fd3077ab6e179d8d0c5770730744823d1c3054847cfeed8c6bbb0eef3e5dL51-R51) [[3]](diffhunk://#diff-90f2fd3077ab6e179d8d0c5770730744823d1c3054847cfeed8c6bbb0eef3e5dL88-R105) [[4]](diffhunk://#diff-90f2fd3077ab6e179d8d0c5770730744823d1c3054847cfeed8c6bbb0eef3e5dL114-R122)

**Settings Update**

* Added a new fetch permission for the domain `www.ideanconsulting.com` in the local settings file (`.claude/settings.local.json`).